### PR TITLE
Fix deploy_services syntax and test-run path

### DIFF
--- a/lib/deployment/deploy_services.sh
+++ b/lib/deployment/deploy_services.sh
@@ -1,4 +1,7 @@
-deploy_services()     # If no password is set in environment, prompt for it
+deploy_services() {
+    local manager_ip="${PI_STATIC_IPS[0]}"
+
+    # If no password is set in environment, prompt for it
     if [[ -z "${PORTAINER_PASSWORD:-}" ]]; then
         echo ""
         echo "🔐 Portainer Admin Password Setup"
@@ -27,14 +30,14 @@ deploy_services()     # If no password is set in environment, prompt for it
             fi
         done
     else
-        local portainer_password="$PORTAINER_PASSWORD"
+        portainer_password="$PORTAINER_PASSWORD"
         # Validate that environment password meets requirements
         if [[ ${#portainer_password} -lt 8 ]]; then
             log WARN "Environment PORTAINER_PASSWORD is less than 8 characters, using default"
             portainer_password="piswarm123"
         fi
-    fi_ip="${PI_STATIC_IPS[0]}"
-    
+    fi
+
     log INFO "Deploying complete service stack (Monitoring + Portainer)..."
     
     # Configure adaptive services based on detected hardware
@@ -49,29 +52,9 @@ deploy_services()     # If no password is set in environment, prompt for it
     
     # Load service status functions
     source "$FUNCTIONS_DIR/monitoring/service_status.sh"
-    
-    # Set environment variables for the deployment
-    if [[ -z "${PORTAINER_PASSWORD:-}" ]]; then
-        echo ""
-        echo "🔐 Portainer Admin Password Setup"
-        echo "================================="
-        echo "Please set a secure password for the Portainer admin account:"
-        echo "(This will be the login password for the web interface)"
-        while true; do
-            read -sp "Enter Portainer admin password: " portainer_password
-            echo ""
-            if [[ -n "$portainer_password" && ${#portainer_password} -ge 8 ]]; then
-                break
-            else
-                echo "❌ Password must be at least 8 characters long. Please try again."
-            fi
-        done
-    else
-        local portainer_password="$PORTAINER_PASSWORD"
-    fi
-    
+
     local grafana_password="${GRAFANA_PASSWORD:-admin}"
-    
+
     # Export cluster information for service deployment
     export_cluster_variables_for_deployment
     

--- a/scripts/testing/test-run.sh
+++ b/scripts/testing/test-run.sh
@@ -20,7 +20,7 @@ if [[ -z "${NODES_DEFAULT_PASS:-}" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/swarm-cluster.sh"
+source core/swarm-cluster.sh
 
 # Colors for output
 readonly GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
- fix malformed deploy_services function definition
- clean up duplicate password prompt logic
- fix path to swarm-cluster in test-run.sh

## Testing
- `bash scripts/testing/test-run.sh --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68409f7b2fbc832a8fe867d38ccd9a91