### PR TITLE
Add pytest suite and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ export NODES_DEFAULT_USER="pi"
 
 For more, see the [docs/](docs/) folder.
 
+## 🧪 Running Tests
+
+Unit tests are located in `tests/`. Install `pytest` and run:
+
+```bash
+pip install pytest
+pytest
+```
+
 ## 🤝 Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/tests/test_network_discovery.py
+++ b/tests/test_network_discovery.py
@@ -1,0 +1,49 @@
+import sys
+sys.path.insert(0, '.')
+
+import pytest
+from lib.python.network_discovery import NetworkDiscovery
+
+
+def test_get_local_network_ranges_offline():
+    nd = NetworkDiscovery(offline_mode=True)
+    ranges = nd.get_local_network_ranges()
+    assert "192.168.1.0/24" in ranges
+    assert "10.0.0.0/24" in ranges
+
+
+def test_ping_host_offline():
+    nd = NetworkDiscovery(offline_mode=True)
+    assert nd.ping_host("192.168.1.100")
+    assert not nd.ping_host("192.168.1.50")
+
+
+def test_ping_host_online_mock(monkeypatch):
+    nd = NetworkDiscovery(offline_mode=False)
+
+    class Result:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def run_mock(*args, **kwargs):
+        return Result(0)
+
+    monkeypatch.setattr("subprocess.run", run_mock)
+    assert nd.ping_host("127.0.0.1")
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: Result(1))
+    assert not nd.ping_host("127.0.0.1")
+
+
+def test_scan_network_range_invalid():
+    nd = NetworkDiscovery(offline_mode=True)
+    devices = nd.scan_network_range("invalid")
+    assert devices == []
+
+
+def test_scan_network_range_offline():
+    nd = NetworkDiscovery(offline_mode=True)
+    devices = nd.scan_network_range("192.168.1.100/30")
+    ips = {d['ip'] for d in devices}
+    assert {"192.168.1.101", "192.168.1.102"} <= ips
+

--- a/tests/test_service_orchestrator.py
+++ b/tests/test_service_orchestrator.py
@@ -1,0 +1,54 @@
+import sys
+sys.path.insert(0, '.')
+
+import pytest
+from lib.python.service_orchestrator import ServiceOrchestrator, ServiceStatus
+
+class DummyOrchestrator(ServiceOrchestrator):
+    def __init__(self):
+        super().__init__(manager_host='localhost')
+        self.commands = []
+
+    def _execute_remote_command(self, command: str, timeout: int = 60):
+        self.commands.append(command)
+        # Simulate success for scale command
+        return True, "scaled", ""
+
+    def get_service_status(self, service_name: str = None):
+        return [ServiceStatus(
+            name=service_name,
+            desired_replicas=1,
+            running_replicas=1,
+            state='running',
+            image='test:latest',
+            created=None,
+            updated=None
+        )]
+
+
+def test_generate_service_templates_names():
+    orch = ServiceOrchestrator('localhost')
+    templates = orch.generate_service_templates()
+    assert {'nginx-web', 'portainer', 'prometheus', 'grafana'} <= set(templates.keys())
+
+
+def test_scale_service_success():
+    orch = DummyOrchestrator()
+    result = orch.scale_service('web', 3)
+    assert result.success
+    assert result.old_replicas == 1
+    assert result.new_replicas == 3
+    assert any('docker service scale web=3' in c for c in orch.commands)
+
+
+def test_scale_service_not_found(monkeypatch):
+    orch = ServiceOrchestrator('localhost')
+
+    def fake_status(name=None):
+        return []
+
+    monkeypatch.setattr(orch, 'get_service_status', fake_status)
+    result = orch.scale_service('missing', 2)
+    assert not result.success
+    assert result.message == 'Service not found'
+


### PR DESCRIPTION
## Summary
- introduce `tests/` directory
- add unit tests for `network_discovery` and `service_orchestrator`
- document running tests via pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843733e3fc4832a9b5d32bcb198da8c