### PR TITLE
Add post-deployment hardening guide

### DIFF
--- a/docs/POST_DEPLOYMENT_HARDENING.md
+++ b/docs/POST_DEPLOYMENT_HARDENING.md
@@ -1,0 +1,38 @@
+# Post-Deployment Hardening
+
+After deploying Pi-Swarm, complete these steps to secure your cluster.
+
+## 1. Change Service Passwords
+
+- **Portainer**: Log in with the initial admin password and immediately change it in the user settings.
+- **Grafana**: Change the default `admin` password in the first login prompt.
+- **Other Services**: Update any credentials configured during deployment.
+
+## 2. Enforce SSH Key Authentication
+
+1. Generate an SSH key pair on your control machine (if you haven't already):
+   ```bash
+   ssh-keygen -t ed25519 -C "pi-swarm"
+   ```
+2. Copy your public key to each Pi node:
+   ```bash
+   ssh-copy-id pi@NODE_IP
+   ```
+3. Edit `/etc/ssh/sshd_config` on each node and set:
+   ```
+   PasswordAuthentication no
+   ```
+   Restart the SSH service to apply the change:
+   ```bash
+   sudo systemctl restart ssh
+   ```
+
+## 3. Review Firewall Settings
+
+- Use `ufw` or `iptables` to allow only required ports (22, 2377, 7946, 4789, 3000, 9000, etc.).
+- Deny all unexpected inbound traffic and restrict management interfaces to trusted networks.
+- Test connectivity after applying firewall rules to ensure cluster communication is unaffected.
+
+---
+
+For additional security recommendations, see [Security Improvements](SECURITY_IMPROVEMENTS.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Pi-Swarm Documentation Index
+
+A quick reference for major guides and resources in this repository.
+
+## Core Guides
+- [Deployment Guide](deployment/DEPLOYMENT_GUIDE.md)
+- [Storage Integration Guide](STORAGE_INTEGRATION_GUIDE.md)
+- [DNS Integration Guide](DNS_INTEGRATION_GUIDE.md)
+- [User Authentication](USER_AUTHENTICATION.md)
+- [Security Improvements](SECURITY_IMPROVEMENTS.md)
+- [Post-Deployment Hardening](POST_DEPLOYMENT_HARDENING.md)
+
+## Enterprise Features
+- [Enterprise Features](enterprise/ENTERPRISE_FEATURES.md)
+- [WhatsApp Integration](enterprise/WHATSAPP_INTEGRATION.md)
+
+## Reference
+- [Directory Structure](DIRECTORY_STRUCTURE.md)
+- [FAQ](FAQ.md)
+- [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -147,6 +147,7 @@ Edit configuration files before deployment:
 - Enable SSH key authentication
 - Consider VPN access for remote management
 - Regular security updates on all Pis
+- See [Post-Deployment Hardening](../POST_DEPLOYMENT_HARDENING.md) for detailed steps
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- document steps for service password changes, SSH key auth, and firewall review
- link to new hardening doc from the deployment guide
- add a documentation index with references to all key docs

## Testing
- `bash scripts/testing/comprehensive-test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684373305114832ab887b7e714a232f4