### PR TITLE
Add .env example and reference in docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment configuration for PI-Swarm
+# Copy this file to '.env' and adjust the values for your setup
+
+PI_NODE_IPS=192.168.1.101,192.168.1.102,192.168.1.103
+NODES_DEFAULT_USER=pi
+MANAGER_IP=192.168.1.101
+NODES_DEFAULT_PASS=your_password
+PI_STATIC_IPS=192.168.1.101 192.168.1.102 192.168.1.103
+

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ chmod +x deploy.sh
 
 # Configure your environment (interactive setup)
 ./scripts/setup-environment.sh
+# Optional: use sample environment file
+cp .env.example .env
 
 # Deploy your Pi-Swarm cluster
 ./deploy.sh
@@ -49,7 +51,8 @@ chmod +x deploy.sh
 
 ### Manual Configuration (Alternative)
 
-If you prefer manual setup, configure environment variables:
+If you prefer manual setup, configure environment variables. A reference
+`.env.example` file is included in the repository:
 
 ```bash
 # Set your Pi node IP addresses

--- a/docs/PORTABLE_CONFIGURATION_GUIDE.md
+++ b/docs/PORTABLE_CONFIGURATION_GUIDE.md
@@ -72,7 +72,7 @@ echo 'export NODES_DEFAULT_USER="pi"' >> ~/.bashrc
 
 ### Method 3: Environment File
 
-Create a `.env` file in the project root:
+Create a `.env` file in the project root (a sample `.env.example` is provided):
 
 ```bash
 # .env file


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholders for Pi-Swarm
- mention the sample env file in the Portable Configuration Guide
- update README quick start and manual configuration sections to use `.env.example`

## Testing
- `bash scripts/testing/simple-test.sh`
- `bash scripts/testing/test-directory-structure.sh > /tmp/testdir.log`
- `bash scripts/testing/simple-validation.sh | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6843731e5b9c832ab5e0f888585014a7