### PR TITLE
Prompt for Pi-hole admin password

### DIFF
--- a/core/swarm-cluster.sh
+++ b/core/swarm-cluster.sh
@@ -767,7 +767,11 @@ if [[ "${ENABLE_PIHOLE:-false}" == "true" ]] && command -v setup_pihole_dns >/de
     
     # Configure Pi-hole DNS with cluster settings
     export PIHOLE_IP="${PIHOLE_IP:-auto}"  # Use first Pi if not specified
-    export PIHOLE_WEB_PASSWORD="${PIHOLE_WEB_PASSWORD:-piswarm123}"
+    if [[ -z "$PIHOLE_WEB_PASSWORD" ]]; then
+        log ERROR "No Pi-hole password supplied. Set PIHOLE_WEB_PASSWORD environment variable."
+        exit 1
+    fi
+    export PIHOLE_WEB_PASSWORD
     export PIHOLE_DNS_UPSTREAM="${PIHOLE_DNS_UPSTREAM:-1.1.1.1,8.8.8.8}"
     export PIHOLE_DOMAIN="${PIHOLE_DOMAIN:-cluster.local}"
     

--- a/deploy.sh
+++ b/deploy.sh
@@ -373,9 +373,13 @@ if [[ "$ENABLE_PIHOLE" =~ ^(y|yes|)$ ]]; then
     export ENABLE_PIHOLE="true"
     export PIHOLE_IP="auto"  # Use first Pi
     export PIHOLE_DOMAIN="cluster.local"
-    export PIHOLE_WEB_PASSWORD="piswarm123"  # Default password
+    if [[ -z "$PIHOLE_WEB_PASSWORD" ]]; then
+        read -s -p "Enter Pi-hole admin password: " PIHOLE_WEB_PASSWORD
+        echo
+    fi
+    export PIHOLE_WEB_PASSWORD
     echo "   DNS domain: cluster.local"
-    echo "   Admin password: piswarm123 (can be changed later)"
+    echo "   Admin password provided"
 else
     echo "⚠️  Pi-hole DNS disabled - using external DNS servers"
     export ENABLE_PIHOLE="false"

--- a/scripts/management/comprehensive-system-repair.sh
+++ b/scripts/management/comprehensive-system-repair.sh
@@ -594,7 +594,11 @@ EOF
         sudo pihole restartdns || echo 'Failed to restart Pi-hole DNS'
         
         # Set Pi-hole admin password
-        echo 'piswarm123' | sudo pihole -a -p || echo 'Failed to set Pi-hole password'
+        if [[ -z "$PIHOLE_WEB_PASSWORD" ]]; then
+            read -s -p "Enter Pi-hole admin password: " PIHOLE_WEB_PASSWORD
+            echo
+        fi
+        echo "$PIHOLE_WEB_PASSWORD" | sudo pihole -a -p || echo 'Failed to set Pi-hole password'
         
         echo 'Pi-hole DNS configuration completed'
     " || print_warning "Pi-hole DNS configuration failed"


### PR DESCRIPTION
## Summary
- ask for Pi-hole admin password in `deploy.sh` instead of using a default
- require `PIHOLE_WEB_PASSWORD` in `core/swarm-cluster.sh`
- prompt for password in `comprehensive-system-repair.sh`

## Testing
- `bash scripts/testing/simple-validation.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843730df980832a87f9dde8e7e81613