### PR TITLE
Update docs for secure credentials

### DIFF
--- a/docs/DNS_INTEGRATION_COMPLETE.md
+++ b/docs/DNS_INTEGRATION_COMPLETE.md
@@ -60,7 +60,7 @@ The Pi-hole DNS server integration has been successfully implemented and integra
   - Portainer: `http://portainer.cluster.local:9000`
   - Grafana: `http://grafana.cluster.local:3000`
 - **Ad Blocking**: Automatic for all cluster traffic
-- **Management**: Web interface with password `piswarm123`
+ - **Management**: Web interface secured with your chosen password
 
 ## 🔧 Key Benefits
 

--- a/docs/DNS_INTEGRATION_GUIDE.md
+++ b/docs/DNS_INTEGRATION_GUIDE.md
@@ -49,7 +49,7 @@ The system will automatically configure:
 |---------|---------------|-------------|
 | **Pi-hole Server** | First Pi in cluster | Which Pi hosts the DNS server |
 | **Domain Name** | `cluster.local` | Local domain for the cluster |
-| **Admin Password** | `piswarm123` | Web interface password |
+| **Admin Password** | *set during deployment* | Web interface password |
 | **Upstream DNS** | `1.1.1.1, 8.8.8.8` | External DNS servers |
 
 ## Usage
@@ -97,7 +97,7 @@ services:
 ### Pi-hole Web Interface
 
 1. **Access**: Navigate to `http://pihole.cluster.local/admin`
-2. **Login**: Use password `piswarm123` (default)
+2. **Login**: Sign in with the password you configured
 3. **Features**:
    - View DNS query logs
    - Manage blocklists

--- a/docs/PORTAINER_INTEGRATION.md
+++ b/docs/PORTAINER_INTEGRATION.md
@@ -33,7 +33,7 @@ Updated `functions/deploy_services.sh` to:
 ### 5. **Environment Configuration**
 Enhanced `functions/configure_pi_headless.sh` to create `.env` file with:
 ```bash
-PORTAINER_PASSWORD=piswarm123
+PORTAINER_PASSWORD=<your-portainer-password>
 GRAFANA_PASSWORD=admin
 PORTAINER_PORT=9443
 PORTAINER_HTTP_PORT=9000
@@ -46,7 +46,7 @@ PROMETHEUS_PORT=9090
 ### **Portainer (Container Management)**
 - **HTTPS**: `https://[manager-ip]:9443` (Recommended - SSL secured)
 - **HTTP**: `http://[manager-ip]:9000` (Alternative access)
-- **Login**: `admin` / `piswarm123`
+- **Login**: `admin` / *your Portainer password*
 - **Features**:
   - Full Docker Swarm management
   - Container deployment and monitoring
@@ -93,7 +93,7 @@ After successful deployment, you'll see:
 🐳 PORTAINER (Container Management):
    • HTTPS: https://[MANAGER-IP]:9443
    • HTTP:  http://[MANAGER-IP]:9000
-   • Login: admin / piswarm123
+   • Login: admin / *your Portainer password*
 
 📊 GRAFANA (Monitoring Dashboard):
    • URL: http://[MANAGER-IP]:3000

--- a/docs/deployment/DEPLOYMENT_COMPLETE.md
+++ b/docs/deployment/DEPLOYMENT_COMPLETE.md
@@ -8,7 +8,7 @@ Your Pi-Swarm system now includes:
 #### **🐳 Portainer CE** - Container Management Platform
 - **HTTPS Access**: `https://[manager-ip]:9443` (SSL secured)
 - **HTTP Access**: `http://[manager-ip]:9000` (backup option)
-- **Default Login**: `admin` / `piswarm123`
+- **Login**: `admin` / *your configured password*
 - **Auto-detects Docker Swarm** and provides full management capabilities
 
 #### **📊 Grafana** - Monitoring Dashboard
@@ -67,7 +67,7 @@ After successful deployment, you'll see:
 🐳 PORTAINER (Container Management):
    • HTTPS: https://[MANAGER-IP]:9443
    • HTTP:  http://[MANAGER-IP]:9000
-   • Login: admin / piswarm123
+   • Login: admin / *your configured password*
 
 📊 GRAFANA (Monitoring Dashboard):
    • URL: http://[MANAGER-IP]:3000
@@ -81,7 +81,7 @@ After successful deployment, you'll see:
 
 1. **Open Portainer**: `https://[manager-ip]:9443`
    - Accept the SSL warning (self-signed certificate)
-   - Login with `admin` / `piswarm123`
+   - Login with `admin` / *your configured password*
    - **Change the password** on first login
    - Portainer automatically detects your Docker Swarm
 

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -54,7 +54,7 @@ Before running any deployment:
 
 3. **Credentials**
    - [ ] You know the username and password for your Pis
-   - [ ] Default credentials: username=`luser`, password=`raspberry`
+   - [ ] **Set unique credentials for each Pi; do not rely on defaults**
 
 4. **Local Machine**
    - [ ] SSH client available
@@ -67,12 +67,12 @@ After successful deployment, you can access:
 ### Management Interfaces
 - **Portainer**: http://YOUR_PI_IP:9000
   - Username: admin
-  - Password: piswarm123 (default)
+  - Password: *your chosen password*
   - Manage containers, services, and swarm
 
 - **Grafana**: http://YOUR_PI_IP:3000
   - Username: admin
-  - Password: admin (default)
+  - Password: admin (change on first login)
   - Monitor cluster performance and health
 
 ### Useful Commands


### PR DESCRIPTION
## Summary
- strengthen credential guidance in deployment docs
- document Portainer password configuration
- clarify Pi-hole admin password setup
- remove outdated default passwords

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684373067614832a9047827b5782ff23